### PR TITLE
Feat: 프로필 완성여부 조회 API의 완료 조건 수정

### DIFF
--- a/src/main/java/Dino/Duett/domain/TestController.java
+++ b/src/main/java/Dino/Duett/domain/TestController.java
@@ -7,32 +7,36 @@ import Dino.Duett.domain.member.entity.Role;
 import Dino.Duett.domain.member.enums.MemberState;
 import Dino.Duett.domain.member.enums.RoleName;
 import Dino.Duett.domain.member.repository.MemberRepository;
-import Dino.Duett.domain.music.dto.request.MusicCreateRequest;
+import Dino.Duett.domain.mood.entity.Mood;
 import Dino.Duett.domain.music.entity.Music;
-import Dino.Duett.domain.music.service.MusicService;
-import Dino.Duett.domain.profile.entity.Profile;
 import Dino.Duett.domain.profile.entity.Location;
+import Dino.Duett.domain.profile.entity.Profile;
 import Dino.Duett.domain.profile.enums.GenderType;
-import Dino.Duett.domain.profile.repository.ProfileRepository;
+import Dino.Duett.domain.profile.enums.MbtiType;
+import Dino.Duett.domain.tag.dto.request.TagRequest;
+import Dino.Duett.domain.tag.enums.TagState;
+import Dino.Duett.domain.tag.service.ProfileTagService;
 import Dino.Duett.global.dto.TokenDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/test")
-public class TestController {
+@Transactional
+public class TestController { // todo: 테스트 이후 삭제 예정
     private final MemberRepository memberRepository;
-    private final ProfileRepository profileRepository;
     private final JwtTokenProvider tokenProvider;
-    private final MusicService musicService;
+    private final ProfileTagService profileTagService;
 
     @PostMapping("/login")
     @Operation(description = "test 로그인", tags = {"테스트"})
@@ -72,20 +76,61 @@ public class TestController {
                 .name(RoleName.USER.name())
                 .build();
 
+        Mood mood1 = Mood.of("title","artist",null);
+        Mood mood2 = Mood.of("title","artist",null);
+
+        List<TagRequest> tagRequest1 =List.of(
+                new TagRequest("팝",TagState.FEATURED),
+                new TagRequest("발라드",TagState.STANDARD),
+                new TagRequest("힙합",TagState.STANDARD)
+        );
+
+        List<TagRequest> tagRequest2 =List.of(
+                new TagRequest("영화",TagState.FEATURED),
+                new TagRequest("콘서트",TagState.STANDARD),
+                new TagRequest("캠핑",TagState.STANDARD)
+        );
+
+
+
+
+        List <Music> musics1 = new ArrayList<>();
+        List <Music> musics2 = new ArrayList<>();
+
+
+        for(int i=0; i< 3; i++){
+            musics1.add(Music.of("title","artist","https://www.youtube.com/watch?v=LnhE5-ONvOc"));
+            musics2.add(Music.of("title","artist","https://www.youtube.com/watch?v=LnhE5-ONvOc"));
+        }
+
         Profile profile1 = Profile.builder()
                 .name("김철수")
                 .gender(GenderType.MAN)
-                .birthDate("1999.01.01")
+                .mbti(MbtiType.ENTJ)
+                .birthDate("2000.01.01")
                 .location(Location.of( 37.5758772, 126.9768121))
                 .profileImage(null)
+                .oneLineIntroduction("안녕하세요")
+                .selfIntroduction("안녕하세요. 반갑습니다! 안녕하세요. 반갑습니다! 안녕하세요. 반갑습니다! 안녕하세요. 반갑습니다! 안녕하세요. 반갑습니다!")
+                .likeableMusicTaste("좋아하는 음악은 없습니다.좋아하는 음악은 없습니다.좋아하는 음악은 없습니다.좋아하는 음악은 없습니다.좋아하는 음악은 없습니다.")
+                .mood(mood1)
+                .musics(musics1)
+                .profileTags(new ArrayList<>())
                 .build();
 
         Profile profile2 = Profile.builder()
                 .name("김영희")
                 .gender(GenderType.WOMAN)
+                .mbti(MbtiType.ENFJ)
                 .birthDate("1999.01.01")
                 .location(Location.of(37.5758772, 126.9768121))
                 .profileImage(null)
+                .oneLineIntroduction("안녕하세요")
+                .selfIntroduction("안녕하세요. 반갑습니다! 안녕하세요. 반갑습니다! 안녕하세요. 반갑습니다! 안녕하세요. 반갑습니다! 안녕하세요. 반갑습니다!")
+                .likeableMusicTaste("좋아하는 음악은 없습니다.좋아하는 음악은 없습니다.좋아하는 음악은 없습니다.좋아하는 음악은 없습니다.좋아하는 음악은 없습니다.")
+                .mood(mood2)
+                .musics(musics2)
+                .profileTags(new ArrayList<>())
                 .build();
 
         Member member1 = Member.builder()
@@ -107,10 +152,11 @@ public class TestController {
                 .build();
 
 
-        profileRepository.save(profile1);
-        profileRepository.save(profile2);
-        memberRepository.save(member1);
-        memberRepository.save(member2);
+        member1 = memberRepository.save(member1);
+        member2 = memberRepository.save(member2);
+
+        profileTagService.changeProfileTags(member1.getId(),tagRequest1,tagRequest2);
+        profileTagService.changeProfileTags(member2.getId(),tagRequest1,tagRequest2);
 
         return member1;
     }

--- a/src/main/java/Dino/Duett/domain/mood/controller/MoodController.java
+++ b/src/main/java/Dino/Duett/domain/mood/controller/MoodController.java
@@ -25,7 +25,7 @@ public class MoodController {
     private final MoodService moodService;
 
     @Operation(summary = "자신의 무드 등록 및 수정", tags = {"테스트"})
-    @PatchMapping("/profiles/mood")
+    @PatchMapping(value = "/profiles/mood", consumes = "multipart/form-data")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "음악 취향 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content(schema = @Schema(hidden = true))),

--- a/src/main/java/Dino/Duett/domain/profile/controller/ProfileCardController.java
+++ b/src/main/java/Dino/Duett/domain/profile/controller/ProfileCardController.java
@@ -28,7 +28,7 @@ public class ProfileCardController implements ProfileCardApi { //todo: 이후에
 //        return JsonBody.of(HttpStatus.OK.value(), "내 프로필 카드 조회 성공", profileCardService.getProfileCard(authMember.getId()));
 //    }
 
-    @Operation(summary = "자신의 프로필 정보가 모두 채워졌는지 조회", tags = {"프로필카드"})
+    @Operation(summary = "자신의 프로필 정보가 채워졌는지 조회", tags = {"프로필카드"})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "자신의 프로필 정보가 모두 채워졌는지 조회"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content(schema = @Schema(hidden = true))),
@@ -38,7 +38,7 @@ public class ProfileCardController implements ProfileCardApi { //todo: 이후에
     })
     @GetMapping("/profile-cards/completion-status")
     public JsonBody<Boolean> getProfileCardCompletionStatus(@AuthenticationPrincipal final AuthMember authMember){
-        return JsonBody.of(HttpStatus.OK.value(), "프로필의 정보가 모두 채워졌는지 조회 성공", profileCardService.getProfileCardCompletionStatus(authMember.getId()));
+        return JsonBody.of(HttpStatus.OK.value(), "프로필의 정보가 채워졌는지 조회 성공", profileCardService.getProfileCardCompletionStatus(authMember.getId()));
     }
 
     @GetMapping("/profile-cards/{profileId}/coin")

--- a/src/main/java/Dino/Duett/domain/profile/entity/Profile.java
+++ b/src/main/java/Dino/Duett/domain/profile/entity/Profile.java
@@ -49,6 +49,7 @@ public class Profile extends BaseEntity {
     private List<ProfileTag> profileTags = new ArrayList<>();
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "mood_id")
     private Mood mood;
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
@@ -57,9 +58,8 @@ public class Profile extends BaseEntity {
     @OneToMany(mappedBy = "viewerProfile", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProfileUnlock> profileUnlocks = new ArrayList<>();
 
-
     @Builder
-    public Profile(Long id, String name, String birthDate, MbtiType mbti, String oneLineIntroduction, String selfIntroduction, String likeableMusicTaste, GenderType gender, Location location, Image profileImage) {
+    public Profile(Long id, String name, String birthDate, MbtiType mbti, String oneLineIntroduction, String selfIntroduction, String likeableMusicTaste, GenderType gender, Location location, Image profileImage, List<ProfileTag> profileTags, Mood mood, List<Music> musics, List<ProfileUnlock> profileUnlocks) {
         this.id = id;
         this.name = name;
         this.birthDate = birthDate;
@@ -70,6 +70,10 @@ public class Profile extends BaseEntity {
         this.gender = gender;
         this.location = location;
         this.profileImage = profileImage;
+        this.profileTags = profileTags;
+        this.mood = mood;
+        this.musics = musics;
+        this.profileUnlocks = profileUnlocks;
     }
 
     public void updateMood(final Mood mood) {

--- a/src/main/java/Dino/Duett/domain/profile/enums/GenderType.java
+++ b/src/main/java/Dino/Duett/domain/profile/enums/GenderType.java
@@ -1,10 +1,7 @@
 package Dino.Duett.domain.profile.enums;
 
-import Dino.Duett.domain.profile.exception.ProfileException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.util.Arrays;
 
 @RequiredArgsConstructor
 @Getter

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileCardService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileCardService.java
@@ -89,7 +89,7 @@ public class ProfileCardService {
      * @param profileId 프로필 id
      * @return ProfileCardResponse
      */
-
+    @Transactional
     public ProfileCardResponse getProfileCardWithCoin(final Long memberId,
                                                       final Long profileId) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberException.MemberNotFoundException::new);
@@ -134,17 +134,39 @@ public class ProfileCardService {
      * @return boolean
      */
     private boolean isProfileComplete(final Profile profile) {
-        return // 내 정보
-                !Validator.isNullOrBlank(profile.getName()) &&
-                !Validator.isNullOrBlank(profile.getOneLineIntroduction()) &&
-                // 내 소개
-                profile.getMbti() != null &&
-                profileTagService.checkFeaturedProfileTagsCount(profile) &&
-                !Validator.isNullOrBlank(profile.getSelfIntroduction()) &&
-                !Validator.isNullOrBlank(profile.getLikeableMusicTaste()) &&
-                // 음악 취향
-                profile.getMusics().size() == MUSIC_MAX_LIMIT.getLimit() &&
-                profile.getMood() != null;
+        int introCount = 0;
+        int musicTasteCount = 0;
+
+        // 내 정보
+        boolean info = !Validator.isNullOrBlank(profile.getName()) &&
+                !Validator.isNullOrBlank(profile.getOneLineIntroduction());
+
+        // 내 소개
+        if (profile.getMbti() != null) {
+            introCount++;
+        }
+        if (profileTagService.checkFeaturedProfileTagsCount(profile)) {
+            introCount++;
+        }
+        if (!Validator.isNullOrBlank(profile.getSelfIntroduction())) {
+            introCount++;
+        }
+        if (!Validator.isNullOrBlank(profile.getLikeableMusicTaste())) {
+            introCount++;
+        }
+        boolean intro = introCount >= 2;
+
+
+        // 음악 취향
+        if (profile.getMusics().size() >= MUSIC_MAX_LIMIT.getLimit()) {
+            musicTasteCount++;
+        }
+        if (profile.getMood() != null) {
+            musicTasteCount++;
+        }
+        boolean musicTaste = musicTasteCount >= 1;
+
+        return info && intro && musicTaste;
     }
 
     /**

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileCardService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileCardService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static Dino.Duett.global.enums.LimitConstants.MUSIC_MAX_LIMIT;
+import static Dino.Duett.global.enums.LimitConstants.*;
 
 
 @Service
@@ -154,7 +154,7 @@ public class ProfileCardService {
         if (!Validator.isNullOrBlank(profile.getLikeableMusicTaste())) {
             introCount++;
         }
-        boolean intro = introCount >= 2;
+        boolean intro = introCount >= PROFILE_INTRO_MIN_SIZE.getLimit();
 
 
         // 음악 취향
@@ -164,7 +164,7 @@ public class ProfileCardService {
         if (profile.getMood() != null) {
             musicTasteCount++;
         }
-        boolean musicTaste = musicTasteCount >= 1;
+        boolean musicTaste = musicTasteCount >= PROFILE_MUSIC_TASTE_MIN_SIZE.getLimit();
 
         return info && intro && musicTaste;
     }

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileUnlockService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileUnlockService.java
@@ -51,6 +51,7 @@ public class ProfileUnlockService {
 
         Page<ProfileUnlock> profileUnlocks = profileUnlockRepository.findAllByViewerProfile(profile, pageable);
         return profileUnlocks.map(profileUnlock -> ProfileCardBriefResponse.builder()
+                .profileId(profileUnlock.getViewedProfile().getId())
                 .name(profileUnlock.getViewedProfile().getName())
                 .birthDate(profileUnlock.getViewedProfile().getBirthDate())
                 .mbti(profileUnlock.getViewedProfile().getMbti())

--- a/src/main/java/Dino/Duett/global/enums/LimitConstants.java
+++ b/src/main/java/Dino/Duett/global/enums/LimitConstants.java
@@ -9,7 +9,9 @@ public enum LimitConstants {
     PROFILE_TAG_MAX_LIMIT(3),
     FEATURED_PROFILE_TAG_MAX_LIMIT(1),
     YOUTUBE_SEARCH_LIMIT(10),
-    MUSIC_MAX_LIMIT(3);
+    MUSIC_MAX_LIMIT(3),
+    PROFILE_INTRO_MIN_SIZE(2),
+    PROFILE_MUSIC_TASTE_MIN_SIZE(1);
 
     private final int limit;
 }


### PR DESCRIPTION
## Description
자신의 프로필 완성 여부를 조회하는 API의 완료 조건 수정

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
<img width="492" alt="스크린샷 2024-06-27 오전 6 44 59" src="https://github.com/CUK-CRUSH/Duett-Server/assets/129057191/ac6ab38d-b93d-4175-8150-bf0f918b43f9">

내 소개 4/4, 음악취향 2/2로 전체를 채워야 다른 사람의 프로필 카드를 조회할 수 있도록 구현  

## What is the new behavior?
내 소개의 2/4, 음악취향의 1/2만 채워도 다른 사람의 프로필 카드를 조회할 수 있도록 변경

## Other information
테스트를 위한 멤버 생성 API (/test/create) 요청시 Music, Mood, Tag도 같이 생성하도록 변경함(이미지는 제외). 이 API는 테스트가 끝나면 추후에 삭제 예정
#23 