### PR TITLE
Fix: 회원가입 프로필 생성되지 않아서 null point exception 발생 수정

### DIFF
--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
@@ -61,7 +61,7 @@ public class ProfileService {
                 .name(signUpReq.getName())
                 .birthDate(signUpReq.getBirthDate())
                 .oneLineIntroduction(signUpReq.getOneLineIntroduction())
-                .gender(GenderType.valueOf(signUpReq.getGender()))
+                .gender(signUpReq.getGender())
                 .location(location)
                 .profileImage(profileImage)
                 .build();

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
@@ -17,7 +17,9 @@ import Dino.Duett.domain.profile.dto.response.ProfileHomeResponse;
 import Dino.Duett.domain.profile.dto.response.ProfileInfoResponse;
 import Dino.Duett.domain.profile.dto.response.ProfileIntroResponse;
 import Dino.Duett.domain.profile.dto.response.ProfileMusicResponse;
+import Dino.Duett.domain.profile.entity.Location;
 import Dino.Duett.domain.profile.entity.Profile;
+import Dino.Duett.domain.profile.enums.GenderType;
 import Dino.Duett.domain.profile.exception.ProfileException;
 import Dino.Duett.domain.profile.repository.ProfileRepository;
 import Dino.Duett.domain.signup.dto.SignUpReq;
@@ -48,10 +50,22 @@ public class ProfileService {
     public void createProfile(final SignUpReq signUpReq) { // todo: 프로필 생성 임시. 수정 바람
         Member member = memberRepository.findByPhoneNumber(signUpReq.getPhoneNumber()).orElseThrow(MemberException.MemberNotFoundException::new);
 
+        // Location 생성
+        Location location = Location.of(signUpReq.getLocation()[0], signUpReq.getLocation()[1]);
+
+        // 프로필 이미지 생성
+        Image profileImage = imageService.saveImage(signUpReq.getProfileImage());
+
         // 프로필 생성
         Profile profile = Profile.builder()
-                .name(signUpReq.getNickname())
+                .name(signUpReq.getName())
+                .birthDate(signUpReq.getBirthDate())
+                .oneLineIntroduction(signUpReq.getOneLineIntroduction())
+                .gender(GenderType.valueOf(signUpReq.getGender()))
+                .location(location)
+                .profileImage(profileImage)
                 .build();
+
         profileRepository.save(profile);
         member.updateProfile(profile);
     }

--- a/src/main/java/Dino/Duett/domain/signup/dto/SignUpReq.java
+++ b/src/main/java/Dino/Duett/domain/signup/dto/SignUpReq.java
@@ -1,6 +1,7 @@
 package Dino.Duett.domain.signup.dto;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -15,17 +16,18 @@ public class SignUpReq {
     @NotBlank
     private String verificationCode;
     @NotBlank
-    private String nickname;
+    private String name;
     @NotBlank
     private String kakaoId;
     @NotBlank
-    private String sex;
+    @Schema(example = "MAN")
+    private String gender;
     @NotBlank
-    private String birth;
+    private String birthDate;
     @NotNull
     private double[] location;
     @NotNull
     private MultipartFile profileImage;
     @NotBlank
-    private String comment;
+    private String oneLineIntroduction;
 }

--- a/src/main/java/Dino/Duett/domain/signup/dto/SignUpReq.java
+++ b/src/main/java/Dino/Duett/domain/signup/dto/SignUpReq.java
@@ -1,6 +1,7 @@
 package Dino.Duett.domain.signup.dto;
 
 
+import Dino.Duett.domain.profile.enums.GenderType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -19,9 +20,9 @@ public class SignUpReq {
     private String name;
     @NotBlank
     private String kakaoId;
-    @NotBlank
+    @NotNull
     @Schema(example = "MAN")
-    private String gender;
+    private GenderType gender;
     @NotBlank
     private String birthDate;
     @NotNull

--- a/src/main/java/Dino/Duett/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/Dino/Duett/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package Dino.Duett.global.handler;
+package Dino.Duett.global.exception;
 
 import Dino.Duett.domain.member.exception.MemberException;
 import Dino.Duett.domain.mood.exception.MoodException;
@@ -6,9 +6,6 @@ import Dino.Duett.domain.music.exception.MusicException;
 import Dino.Duett.domain.profile.exception.ProfileException;
 import Dino.Duett.domain.search.exception.YoutubeException;
 import Dino.Duett.domain.tag.exception.TagException;
-import Dino.Duett.global.exception.CustomException;
-import Dino.Duett.global.exception.ErrorCode;
-import Dino.Duett.global.exception.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/test/java/Dino/Duett/domain/search/controller/SearchControllerTest.java
+++ b/src/test/java/Dino/Duett/domain/search/controller/SearchControllerTest.java
@@ -1,19 +1,14 @@
 package Dino.Duett.domain.search.controller;
 
-import Dino.Duett.config.EnvBean;
 import Dino.Duett.domain.member.entity.Member;
 import Dino.Duett.domain.member.repository.MemberRepository;
-import Dino.Duett.domain.music.repository.MusicRepository;
-import Dino.Duett.domain.search.service.SearchService;
 import Dino.Duett.utils.TestUtil;
 import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -38,7 +33,7 @@ public class SearchControllerTest {
         // given
         final String GET_API = "/api/v1/search/video";
 
-        Member member = testUtil.createMember();
+        Member member = testUtil.makeMember();
         memberRepository.save(member);
 
         // when

--- a/src/test/java/Dino/Duett/test/controller/AuthenticationControllerTest.java
+++ b/src/test/java/Dino/Duett/test/controller/AuthenticationControllerTest.java
@@ -59,7 +59,7 @@ public class AuthenticationControllerTest {
     public void checkMemberTestWithRegisteredMember(TestReporter testReporter) throws Exception {
         // given
         String phoneNumber = TestUtil.MEMBER_PHONE_NUMBER;
-        memberRepository.save(TestUtil.createMember());
+        memberRepository.save(TestUtil.makeMember());
         // when, then
         testReporter.publishEntry(mockMvc.perform(
                 get("/api/v1/authentication/member/exists")

--- a/src/test/java/Dino/Duett/test/controller/SignUpControllerTest.java
+++ b/src/test/java/Dino/Duett/test/controller/SignUpControllerTest.java
@@ -1,6 +1,8 @@
 package Dino.Duett.test.controller;
 
 import Dino.Duett.domain.authentication.VerificationCodeManager;
+import Dino.Duett.domain.image.entity.Image;
+import Dino.Duett.domain.image.service.ImageService;
 import Dino.Duett.domain.signup.dto.SignUpReq;
 import Dino.Duett.gmail.GmailReader;
 import Dino.Duett.utils.TestUtil;
@@ -18,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,6 +40,10 @@ public class SignUpControllerTest {
     // 실제 GmailReader를 사용하지 않고 Mocking
     @MockBean
     private GmailReader gmailReader;
+    @MockBean
+    private ImageService imageService;
+    @Autowired
+    private TestUtil testUtil;
 
     @Test
     @DisplayName("회원가입 테스트")
@@ -46,29 +53,24 @@ public class SignUpControllerTest {
         // GmailReader에서 validate() 메서드에서 예외가 발생하지 않게 하기 위해 Mocking
         doAnswer(invocation -> null).when(gmailReader).validate(anyString(), anyString());
 
+        Image image = testUtil.createImage();
+        given(imageService.saveImage(any())).willReturn(image);
+
         SignUpReq signUpReq = TestUtil.makeSignUpReq();
         signUpReq.setVerificationCode(verificationCode);
-
-        // MockMultipartFile 객체를 생성하여 파일을 만듭니다.
-        MockMultipartFile profileImage = new MockMultipartFile(
-                "profileImage",
-                "profile.jpg",
-                MediaType.IMAGE_JPEG_VALUE,
-                "Profile Image Content".getBytes()
-        );
 
         // when, then
         testReporter.publishEntry(mockMvc.perform(
                     multipart("/api/v1/sign-up")
-                            .file(profileImage)
+                            .file((MockMultipartFile) signUpReq.getProfileImage())
                             .param("phoneNumber", signUpReq.getPhoneNumber())
-                            .param("verificationCode", verificationCode)
-                            .param("nickname", signUpReq.getNickname())
+                            .param("verificationCode", signUpReq.getVerificationCode())
+                            .param("name", signUpReq.getName())
                             .param("kakaoId", signUpReq.getKakaoId())
-                            .param("sex", signUpReq.getSex())
-                            .param("birth", signUpReq.getBirth())
+                            .param("gender", signUpReq.getGender())
+                            .param("birthDate", signUpReq.getBirthDate())
                             .param("location", signUpReq.getLocation()[0] + "," + signUpReq.getLocation()[1])
-                            .param("comment", signUpReq.getComment())
+                            .param("oneLineIntroduction", signUpReq.getOneLineIntroduction())
                             .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
                 )
                     .andExpect(status().isOk())

--- a/src/test/java/Dino/Duett/test/controller/SignUpControllerTest.java
+++ b/src/test/java/Dino/Duett/test/controller/SignUpControllerTest.java
@@ -67,7 +67,7 @@ public class SignUpControllerTest {
                             .param("verificationCode", signUpReq.getVerificationCode())
                             .param("name", signUpReq.getName())
                             .param("kakaoId", signUpReq.getKakaoId())
-                            .param("gender", signUpReq.getGender())
+                            .param("gender", signUpReq.getGender().name())
                             .param("birthDate", signUpReq.getBirthDate())
                             .param("location", signUpReq.getLocation()[0] + "," + signUpReq.getLocation()[1])
                             .param("oneLineIntroduction", signUpReq.getOneLineIntroduction())

--- a/src/test/java/Dino/Duett/test/service/MemberServiceTest.java
+++ b/src/test/java/Dino/Duett/test/service/MemberServiceTest.java
@@ -35,7 +35,7 @@ public class MemberServiceTest {
     @DisplayName("member 생성 테스트")
     public void createMemberTest() {
         // given
-        Member inputMember = TestUtil.createMember();
+        Member inputMember = TestUtil.makeMember();
 
         given(memberRepository.existsByPhoneNumber(inputMember.getPhoneNumber())).willReturn(false);
         given(memberRepository.existsByKakaoId(inputMember.getKakaoId())).willReturn(false);
@@ -64,7 +64,7 @@ public class MemberServiceTest {
     @DisplayName("member dto 생성 테스트")
     public void makeMemberDtoTest() {
         // given
-        Member member = TestUtil.createMember();
+        Member member = TestUtil.makeMember();
 
         // when
         MemberDto memberDto = memberService.makeMemberDto(member);

--- a/src/test/java/Dino/Duett/utils/TestUtil.java
+++ b/src/test/java/Dino/Duett/utils/TestUtil.java
@@ -53,7 +53,7 @@ public class TestUtil {
         signUpReq.setVerificationCode("code");
         signUpReq.setName(MEMBER_NICKNAME);
         signUpReq.setKakaoId(MEMBER_KAKAO_ID);
-        signUpReq.setGender("MAN");
+        signUpReq.setGender(GenderType.MAN);
         signUpReq.setBirthDate("1997-10-31");
         signUpReq.setLocation(new double[]{1.1, 2.2});
         signUpReq.setProfileImage(multipartFile);

--- a/src/test/java/Dino/Duett/utils/TestUtil.java
+++ b/src/test/java/Dino/Duett/utils/TestUtil.java
@@ -2,6 +2,8 @@ package Dino.Duett.utils;
 
 import Dino.Duett.config.login.jwt.JwtTokenProvider;
 import Dino.Duett.config.login.jwt.JwtTokenType;
+import Dino.Duett.domain.image.entity.Image;
+import Dino.Duett.domain.image.repository.ImageRepository;
 import Dino.Duett.domain.member.entity.Member;
 import Dino.Duett.domain.member.entity.Role;
 import Dino.Duett.domain.member.enums.MemberState;
@@ -36,6 +38,8 @@ public class TestUtil {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    private ImageRepository imageRepository;
 
     /**
      * 테스트용 회원가입 요청 생성
@@ -47,13 +51,13 @@ public class TestUtil {
 
         signUpReq.setPhoneNumber(MEMBER_PHONE_NUMBER);
         signUpReq.setVerificationCode("code");
-        signUpReq.setNickname(MEMBER_NICKNAME);
+        signUpReq.setName(MEMBER_NICKNAME);
         signUpReq.setKakaoId(MEMBER_KAKAO_ID);
-        signUpReq.setSex("male");
-        signUpReq.setBirth("1997-10-31");
+        signUpReq.setGender("MAN");
+        signUpReq.setBirthDate("1997-10-31");
         signUpReq.setLocation(new double[]{1.1, 2.2});
         signUpReq.setProfileImage(multipartFile);
-        signUpReq.setComment("comment");
+        signUpReq.setOneLineIntroduction("comment");
 
         return signUpReq;
     }
@@ -76,7 +80,7 @@ public class TestUtil {
      * 테스트용 멤버 생성. id 1의 role 사용해서 만듦. 멤버 id는 생성되지 않음.
      * @return Member
     * */
-    public static Member createMember() {
+    public static Member makeMember() {
         // 역할 생성
         Role role = Role.builder()
                 .id(1L)
@@ -146,5 +150,13 @@ public class TestUtil {
                         .build())
                 .build();
         return member;
+    }
+
+    public Image createImage() {
+        return imageRepository.save(Image.builder()
+                .name("image")
+                .extension("webp")
+                .uuid("uuid")
+                .build());
     }
 }


### PR DESCRIPTION
## Description
회원가입 프로필 생성되지 않아서 null point exception 발생 수정

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [x] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [x] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
- 회원가입에서 프로필 생성이 생략되어 있음. 내 정보 조회같은 기능을 사용하면 null point exception 발생

## What is the new behavior?
- 회원가입에서 프로필 생성 추가

## Other information