### PR TITLE
Feat: 내 정보 등록 및 수정하기 유저 네임 중복 체크

### DIFF
--- a/src/main/java/Dino/Duett/domain/profile/controller/ProfileApi.java
+++ b/src/main/java/Dino/Duett/domain/profile/controller/ProfileApi.java
@@ -36,6 +36,7 @@ public interface ProfileApi {
             @ApiResponse(responseCode = "400", description = "잘못된 인자 입력, 유효성 검사 실패", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "2003", description = "사용자를 찾을 수 없음(404)", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "5000", description = "프로필을 찾을 수 없음(404)", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "5003", description = "이미 존재하는 유저 네임(400)", content = @Content(schema = @Schema(hidden = true))),
     })
     public JsonBody<Void> updateProfileInfo(@AuthenticationPrincipal final AuthMember authMember,
                                             @Validated @ModelAttribute final ProfileInfoRequest profileInfoRequest);

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
@@ -155,6 +155,10 @@ public class ProfileService {
         Image image = profile.getProfileImage();
         MultipartFile imageFile = profileInfoRequest.getProfileImage();
 
+        if (profileRepository.existsByName(profileInfoRequest.getName())) {
+            throw new ProfileException.ProfileUsernameExistException();
+        }
+
         if (!Validator.isNullOrEmpty(imageFile)) {
             if (image != null) {
                 if(profileInfoRequest.getIsDeleteImage() == null || profileInfoRequest.getIsDeleteImage()) {

--- a/src/main/java/Dino/Duett/domain/signup/controller/SignUpController.java
+++ b/src/main/java/Dino/Duett/domain/signup/controller/SignUpController.java
@@ -5,6 +5,10 @@ import Dino.Duett.domain.signup.dto.SignUpRes;
 import Dino.Duett.domain.signup.service.SignUpService;
 import Dino.Duett.global.dto.JsonBody;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +25,12 @@ public class SignUpController {
     private final SignUpService signUpService;
 
     @Operation(summary = "회원가입")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "2000", description = "전화번호 중복(400)", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "2001", description = "카카오 중복(400)", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "5003", description = "이미 존재하는 유저 이름(400)", content = @Content(schema = @Schema(hidden = true))),
+    })
     @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public JsonBody<SignUpRes> signUp(@Valid SignUpReq signUpReq) {
         return JsonBody.of(200, "회원가입 성공", signUpService.signUp(signUpReq));

--- a/src/main/java/Dino/Duett/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/Dino/Duett/global/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
@@ -66,6 +67,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({
             TagException.ProfileTagMaxLimitException.class,
+            MemberException.DuplicateKakaoIdException.class,
+            MemberException.DuplicatePhoneNumberException.class,
             ProfileException.ProfileIncompleteException.class,
             ProfileException.ProfileUsernameExistException.class
         }


### PR DESCRIPTION
## Description
전화번호,  카카오ID 중복 statusCode 수정
내 정보 등록 및 수정하기에 이름 중복 확인 처리

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [x] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
전화번호, 카카오 ID 중복 시 statuscode가 500임
프로필 수정하기에서 이미 존재하는 유저 처리가 누락됨

## What is the new behavior?
전화번호, 카카오 ID 중복 시 statuscode가 400 적용


## Other information
#30