### PR TITLE
Feat: 프로필 태그를 생성순으로 정렬

### DIFF
--- a/src/main/java/Dino/Duett/domain/music/dto/response/MusicResponse.java
+++ b/src/main/java/Dino/Duett/domain/music/dto/response/MusicResponse.java
@@ -1,6 +1,7 @@
 package Dino.Duett.domain.music.dto.response;
 
 import Dino.Duett.domain.music.entity.Music;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -20,6 +21,7 @@ public class MusicResponse {
     @Schema(description = "아티스트 이름", name = "artist")
     private String artist;
     @Schema(description = "유튜브 url", name = "url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String url;
 
     public static MusicResponse of(Music music){
@@ -29,7 +31,15 @@ public class MusicResponse {
                 music.getArtist(),
                 music.getUrl());
     }
-
+    public static MusicResponse of(Long musicId,
+                                   String title,
+                                   String artist){
+        return new MusicResponse(
+                musicId,
+                title,
+                artist,
+                null);
+    }
     public static List<MusicResponse> of(List<Music> musics){
         return musics.stream()
                 .map(MusicResponse::of)

--- a/src/main/java/Dino/Duett/domain/music/exception/MusicException.java
+++ b/src/main/java/Dino/Duett/domain/music/exception/MusicException.java
@@ -1,5 +1,6 @@
 package Dino.Duett.domain.music.exception;
 
+import Dino.Duett.domain.profile.exception.ProfileException;
 import Dino.Duett.global.exception.CustomException;
 import Dino.Duett.global.exception.ErrorCode;
 
@@ -28,6 +29,13 @@ public class MusicException extends CustomException {
             super(ErrorCode.MUSIC_MAX_LIMIT, property);
         }
     }
-
+    public static class MusicForbiddenException extends MusicException {
+        public MusicForbiddenException() {
+            super(ErrorCode.MUSIC_FORBIDDEN);
+        }
+        public MusicForbiddenException(Map<String, String> property) {
+            super(ErrorCode.MUSIC_FORBIDDEN, property);
+        }
+    }
     
 }

--- a/src/main/java/Dino/Duett/domain/profile/controller/ProfileController.java
+++ b/src/main/java/Dino/Duett/domain/profile/controller/ProfileController.java
@@ -54,7 +54,7 @@ public class ProfileController implements ProfileApi{ //todo: 이후에 API 문�
         return JsonBody.of(HttpStatus.OK.value(), "자신의 음악 취향(인생곡과 무드) 조회", profileService.getProfileMusic(authMember.getMemberId()));
     }
 
-    @Operation(summary = "자신의 음악 취향(인생곡과 무드) 한번에 추가, 수정, 삭제하기", tags = {"테스트"})
+    @Operation(summary = "자신의 음악 취향(인생곡과 무드) 한번에 추가, 수정, 삭제하기", tags = {"테스트"}) //todo: 삭제 예정
     @PostMapping(value = "/profiles/music-taste", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "음악 취향 조회 성공"),

--- a/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileCardBriefResponse.java
+++ b/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileCardBriefResponse.java
@@ -21,7 +21,7 @@ public class ProfileCardBriefResponse {
     String birthDate;
     @Schema(description = "MBTI 유형", example = "ENTP")
     MbtiType mbti;
-    @Schema(description = "인생곡", example = "[{\"title\": \"title\", \"artist\": \"artist\", \"url\": \"url\"}]")
+    @Schema(description = "인생곡", example = "[{\"title\": \"title\", \"artist\": \"artist\"]")
     MusicResponse lifeMusic;
     @Schema(description = "태그", example = "[{\"name\": \"팝\", \"state\": \"FEATURED\"}, {\"name\": \"발라드\", \"state\": \"STANDARD\"}]")
     List<TagResponse> tags;

--- a/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileCardResponse.java
+++ b/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileCardResponse.java
@@ -18,7 +18,7 @@ public class ProfileCardResponse {
     Long profileId;
     @Schema(description = "사용자의 이름", example = "name")
     String name;
-    @Schema(description = "사용자의 생년월일", example = "2000.01.01")
+    @Schema(description = "사용자의 생년월일", example = "2000년 01월 01일")
     String birthDate;
     @Schema(description = "MBTI 유형", example = "ENTP")
     MbtiType mbti;
@@ -34,7 +34,7 @@ public class ProfileCardResponse {
     List<TagResponse> hobbyTags;
     @Schema(description = "인생곡 리스트", example = "[{\"title\": \"title\", \"artist\": \"artist\", \"url\": \"url\"}]")
     List<MusicResponse> lifeMusics;
-    @Schema(description = "mood 정보", example = "{\"title\": \"title\", \"artist\": \"artist\", \"moodImage\": \"https://duett-mood-image/image.jpg\", \"isDeleteImage\": \"true\" }")
+    @Schema(description = "mood 정보", example = "{\"title\": \"title\", \"artist\": \"artist\", \"moodImageUrl\": \"https://duett-mood-image/image.jpg\"}")
     MoodResponse mood;
     @Schema(description = "긴 자기 소개", example = "crush")
     String selfIntroduction;

--- a/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileCardSummaryResponse.java
+++ b/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileCardSummaryResponse.java
@@ -3,7 +3,6 @@ package Dino.Duett.domain.profile.dto.response;
 import Dino.Duett.domain.music.dto.response.MusicResponse;
 import Dino.Duett.domain.profile.enums.MbtiType;
 import Dino.Duett.domain.tag.dto.response.TagResponse;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileUnlockService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileUnlockService.java
@@ -56,7 +56,11 @@ public class ProfileUnlockService {
                 .birthDate(profileUnlock.getViewedProfile().getBirthDate())
                 .mbti(profileUnlock.getViewedProfile().getMbti())
                 .lifeMusic(profileUnlock.getViewedProfile().getMusics() !=null && !profileUnlock.getViewedProfile().getMusics().isEmpty() ?
-                                MusicResponse.of(profileUnlock.getViewedProfile().getMusics().get(0)) : null)
+                                MusicResponse.of(
+                                        profileUnlock.getViewedProfile().getMusics().get(0).getId(),
+                                        profileUnlock.getViewedProfile().getMusics().get(0).getTitle(),
+                                        profileUnlock.getViewedProfile().getMusics().get(0).getArtist()
+                                ) : null)
                 .tags(profileTagService.getProfileTagsOnlyFeatured(profileUnlock.getId()))
                 .build()).stream()
                 .toList();

--- a/src/main/java/Dino/Duett/domain/tag/entity/ProfileTag.java
+++ b/src/main/java/Dino/Duett/domain/tag/entity/ProfileTag.java
@@ -2,6 +2,7 @@ package Dino.Duett.domain.tag.entity;
 
 import Dino.Duett.domain.profile.entity.Profile;
 import Dino.Duett.domain.tag.enums.TagState;
+import Dino.Duett.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "profile_tag")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ProfileTag {
+public class ProfileTag extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "profile_tag_id")

--- a/src/main/java/Dino/Duett/domain/tag/repository/ProfileTagRepository.java
+++ b/src/main/java/Dino/Duett/domain/tag/repository/ProfileTagRepository.java
@@ -17,7 +17,8 @@ public interface ProfileTagRepository extends JpaRepository<ProfileTag, Long> {
     @Query("SELECT t.name as name, pt.state as state " +
             "FROM ProfileTag pt " +
             "JOIN pt.tag t " +
-            "WHERE pt.profile.id = :profileId AND t.type = :type")
+            "WHERE pt.profile.id = :profileId AND t.type = :type " +
+            "ORDER BY pt.createdDate ASC")
     List<ProfileTagProjection> findByProfileIdAndTagType(
             @Param("profileId") Long profileId,
             @Param("type") TagType type);

--- a/src/main/java/Dino/Duett/global/exception/ErrorCode.java
+++ b/src/main/java/Dino/Duett/global/exception/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
     // 6000: Music
     MUSIC_NOT_FOUND(6000, "음악을 찾을 수 없습니다"),
     MUSIC_MAX_LIMIT(6001, "음악 최대 개수 초과"),
+    MUSIC_FORBIDDEN(6002, "음악 접근 권한이 없습니다"),
 
     // 7000: Mood
     MOOD_NOT_FOUND(7000, "무드를 찾을 수 없습니다."),


### PR DESCRIPTION
## Description
- 프로필 태그를 생성순으로 정렬
- 자신의 음악만 수정할 수 있게 예외처리 추가

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
- 최근에 수정한 순서가 프로필 태그의 정렬 순서였음. 
- 따라서 STANDARD 상태를 FEATURED 상태로 변경할 시 순서가 유지되지 않고 섞이는 상태.

## What is the new behavior?
- 프로필 태그를 생성한 순서로 변경해서 정렬 순서를 고정하도록 함

## Other information
#11 