### PR TITLE
[fix] ProfileCardBriefResponse에 LocalDateTime 칼럼 추가

### DIFF
--- a/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileCardBriefResponse.java
+++ b/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileCardBriefResponse.java
@@ -1,12 +1,14 @@
 package Dino.Duett.domain.profile.dto.response;
 
 import Dino.Duett.domain.tag.dto.response.TagResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import Dino.Duett.domain.music.dto.response.MusicResponse;
 import Dino.Duett.domain.profile.enums.MbtiType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "프로필 간략 응답")
@@ -25,5 +27,8 @@ public class ProfileCardBriefResponse {
     MusicResponse lifeMusic;
     @Schema(description = "태그", example = "[{\"name\": \"팝\", \"state\": \"FEATURED\"}, {\"name\": \"발라드\", \"state\": \"STANDARD\"}]")
     List<TagResponse> tags;
+    @Schema(description = "받은 좋아요 날짜", example = "2024-07-16T05:46:26.499Z")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    LocalDateTime likeDate;
 }
 

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileCardService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileCardService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -296,7 +297,7 @@ public class ProfileCardService {
                 .build();
     }
 
-    public ProfileCardBriefResponse convertToBriefDto(Profile profile) {
+    public ProfileCardBriefResponse convertToBriefDto(Profile profile, LocalDateTime likeDate) {
         return ProfileCardBriefResponse.builder()
                 .profileId(profile.getId())
                 .name(profile.getName())
@@ -304,6 +305,7 @@ public class ProfileCardService {
                 .mbti(profile.getMbti())
                 .lifeMusic(profile.getMusics().stream().findFirst().map(MusicResponse::of).orElse(null))
                 .tags(profileTagService.getProfileTagsOnlyFeatured(profile.getId()))
+                .likeDate(likeDate)
                 .build();
     }
 }

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileLikeService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileLikeService.java
@@ -65,7 +65,7 @@ public class ProfileLikeService {
         Member member = memberRepository.findById(memberId).orElseThrow();
         List<ProfileLike> profileLikes = profileLikeRepository.findByMember(member);
         return profileLikes.stream()
-                .map(profileLike -> profileCardService.convertToBriefDto(profileLike.getLikedProfile()))
+                .map(profileLike -> profileCardService.convertToBriefDto(profileLike.getLikedProfile(), profileLike.getCreatedDate()))
                 .collect(Collectors.toList());
     }
 
@@ -74,7 +74,7 @@ public class ProfileLikeService {
         Member member = memberRepository.findById(memberId).orElseThrow();
         List<ProfileLike> profileLikes = profileLikeRepository.findByLikedProfile(member.getProfile(), pageable);
         return profileLikes.stream()
-                .map(profileLike -> profileCardService.convertToBriefDto(profileLike.getMember().getProfile()))
+                .map(profileLike -> profileCardService.convertToBriefDto(profileLike.getMember().getProfile(), profileLike.getCreatedDate()))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Description
ProfileCardBriefResponse에 LocalDateTime(likeDate) 칼럼을 추가하여 언제 좋아요를 받았는지 확인할 수 있습니다.

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
언제 좋아요를 받았는지 확인할 수 없었습니다.

## What is the new behavior?
ProfileCardBriefResponse에 LocalDateTime(likeDate) 칼럼을 추가하여 언제 좋아요를 받았는지 확인할 수 있습니다.

## Other information