### PR TITLE
[Feat] Message Response에 ProfileBriefResponse 추가

### DIFF
--- a/src/main/java/Dino/Duett/domain/message/controller/MessageController.java
+++ b/src/main/java/Dino/Duett/domain/message/controller/MessageController.java
@@ -4,7 +4,9 @@ import Dino.Duett.config.security.AuthMember;
 import Dino.Duett.domain.message.dto.request.MessageDeleteRequest;
 import Dino.Duett.domain.message.dto.request.MessageSendRequest;
 import Dino.Duett.domain.message.dto.response.MessageDeleteResponse;
+import Dino.Duett.domain.message.dto.response.MessageReceiveResponse;
 import Dino.Duett.domain.message.dto.response.MessageResponse;
+import Dino.Duett.domain.message.dto.response.MessageSendResponse;
 import Dino.Duett.domain.message.service.MessageService;
 import Dino.Duett.global.dto.JsonBody;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,7 +32,7 @@ public class MessageController {
     @GetMapping("/receive/all")
     @Operation(summary = "수신한 모든 메시지 조회. paging 처리되어있음", tags = {"메시지"})
     @ApiResponse(responseCode = "200", description = "모든 수신 메시지 조회 성공")
-    public JsonBody<List<MessageResponse>> getAllReceiveMessages(
+    public JsonBody<List<MessageReceiveResponse>> getAllReceiveMessages(
             @AuthenticationPrincipal final AuthMember authMember,
             @RequestParam(name = "page", required = false, defaultValue = "0") @PositiveOrZero Integer page) {
         return JsonBody.of(HttpStatus.OK.value(), "모든 수신 메시지 조회 성공", messageService.getAllReceiveMessages(authMember.getMemberId(), page));
@@ -40,7 +42,7 @@ public class MessageController {
     @GetMapping("/send/all")
     @Operation(summary = "발신한 모든 메시지 조회. paging 처리되어있음", tags = {"메시지"})
     @ApiResponse(responseCode = "200", description = "모든 발신 메시지 조회 성공")
-    public JsonBody<List<MessageResponse>> getAllSendMessages(
+    public JsonBody<List<MessageSendResponse>> getAllSendMessages(
             @AuthenticationPrincipal final AuthMember authMember,
             @RequestParam(name = "page", required = false, defaultValue = "0") @PositiveOrZero Integer page) {
         return JsonBody.of(HttpStatus.OK.value(), "모든 발신 메시지 조회 성공", messageService.getAllSendMessages(authMember.getMemberId(), page));

--- a/src/main/java/Dino/Duett/domain/message/dto/response/MessageReceiveResponse.java
+++ b/src/main/java/Dino/Duett/domain/message/dto/response/MessageReceiveResponse.java
@@ -1,0 +1,36 @@
+package Dino.Duett.domain.message.dto.response;
+
+import Dino.Duett.domain.profile.dto.response.ProfileCardBriefResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "수신 메세지 리스트 응답")
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class MessageReceiveResponse {
+    @Schema(description = "보낸 사람 프로파일 정보")
+    @NotNull
+    private final ProfileCardBriefResponse sender;
+
+    @Schema(description = "받은 사람 ID", example = "2")
+    @NotNull
+    private final Long receiverId;
+
+    @Schema(description = "메세지 내용", example = "안녕하세요")
+    @NotBlank
+    private final String content;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String senderName;
+
+    @Schema(description = "받은 메세지 날짜", example = "2024-07-16T05:46:26.499Z")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final LocalDateTime messageDate;
+}

--- a/src/main/java/Dino/Duett/domain/message/dto/response/MessageResponse.java
+++ b/src/main/java/Dino/Duett/domain/message/dto/response/MessageResponse.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Schema(description = "메세지 응답")
 @Getter
 @RequiredArgsConstructor(staticName = "of")
-@NoArgsConstructor(force = true) // 기본 생성자 추가
 public class MessageResponse {
     @Schema(description = "보낸 사람 ID", example = "1")
     @NotNull

--- a/src/main/java/Dino/Duett/domain/message/dto/response/MessageResponse.java
+++ b/src/main/java/Dino/Duett/domain/message/dto/response/MessageResponse.java
@@ -1,22 +1,30 @@
 package Dino.Duett.domain.message.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
 
+@Schema(description = "메세지 응답")
 @Getter
 @RequiredArgsConstructor(staticName = "of")
+@NoArgsConstructor(force = true) // 기본 생성자 추가
 public class MessageResponse {
+    @Schema(description = "보낸 사람 ID", example = "1")
     @NotNull
     private final Long senderId;
+
+    @Schema(description = "받은 사람 ID", example = "2")
     @NotNull
     private final Long receiverId;
+
+    @Schema(description = "메세지 내용", example = "안녕하세요")
     @NotBlank
     private final String content;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private final String senderName;
 }
+

--- a/src/main/java/Dino/Duett/domain/message/dto/response/MessageSendResponse.java
+++ b/src/main/java/Dino/Duett/domain/message/dto/response/MessageSendResponse.java
@@ -1,0 +1,36 @@
+package Dino.Duett.domain.message.dto.response;
+
+import Dino.Duett.domain.profile.dto.response.ProfileCardBriefResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "발신 메세지 리스트 응답")
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class MessageSendResponse {
+    @Schema(description = "보낸 사람 ID", example = "1")
+    @NotNull
+    private final Long senderId;
+
+    @Schema(description = "받은 사람 프로파일 정보")
+    @NotNull
+    private final ProfileCardBriefResponse receiver;
+
+    @Schema(description = "메세지 내용", example = "안녕하세요")
+    @NotBlank
+    private final String content;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String senderName;
+
+    @Schema(description = "받은 메세지 날짜", example = "2024-07-16T05:46:26.499Z")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final LocalDateTime messageDate;
+}

--- a/src/main/java/Dino/Duett/global/dummy/DummyController.java
+++ b/src/main/java/Dino/Duett/global/dummy/DummyController.java
@@ -221,7 +221,7 @@ public class DummyController { // todo: 테스트 이후 API 삭제 예정
                 .build();
     }
 
-    private Member createDummyMember(){
+    public Member createDummyMember(){
         Member member = Member.builder()
                 .phoneNumber(UUID.randomUUID().toString().substring(0, 11))
                 .kakaoId(UUID.randomUUID().toString().substring(0, 8))

--- a/src/test/java/Dino/Duett/test/controller/MessageControllerTest.java
+++ b/src/test/java/Dino/Duett/test/controller/MessageControllerTest.java
@@ -30,12 +30,16 @@ public class MessageControllerTest {
     @Autowired
     private TestUtil testUtil;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+
     @Test
     @DisplayName("모든 수신 메시지 조회 테스트")
     public void getAllReceiveMessagesTest(TestReporter testReporter) throws Exception {
         // given
         // 메시지 생성
-        Member sender = testUtil.createTestMember();
+        Member sender = testUtil.createTestMemberWithProfile();
         Member receiver = testUtil.createTestMember();
         Message message = testUtil.createTestMessage(sender, receiver);
         // 토큰 생성
@@ -48,20 +52,22 @@ public class MessageControllerTest {
 
         // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].senderId").value(sender.getId()))
+                .andExpect(jsonPath("$.data[0].sender.profileId").value(sender.getProfile().getId()))
                 .andReturn().getResponse().getContentAsString());
     }
 
     @Test
     @DisplayName("모든 발신 메시지 조회 테스트")
+
     public void getAllSendMessagesTest(TestReporter testReporter) throws Exception {
         // given
         // 메시지 생성
         Member sender = testUtil.createTestMember();
-        Member receiver = testUtil.createTestMember();
+        Member receiver = testUtil.createTestMemberWithProfile();
         Message message = testUtil.createTestMessage(sender, receiver);
         // 토큰 생성
         String receiverToken = testUtil.createAccessToken(sender.getId());
+        System.out.println(receiver.getId());
 
         // when
         // 모든 메시지 조회 요청
@@ -70,7 +76,7 @@ public class MessageControllerTest {
 
                 // then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].receiverId").value(receiver.getId()))
+                .andExpect(jsonPath("$.data[0].receiver.profileId").value(receiver.getProfile().getId()))
                 .andReturn().getResponse().getContentAsString());
     }
 

--- a/src/test/java/Dino/Duett/utils/TestUtil.java
+++ b/src/test/java/Dino/Duett/utils/TestUtil.java
@@ -17,10 +17,13 @@ import Dino.Duett.domain.profile.enums.GenderType;
 import Dino.Duett.domain.signup.dto.SignUpReq;
 import Dino.Duett.domain.tag.entity.Tag;
 import Dino.Duett.domain.tag.enums.TagType;
+import Dino.Duett.global.dummy.DummyController;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.checkerframework.checker.units.qual.A;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -57,6 +60,8 @@ public class TestUtil {
     private MemberRepository memberRepository;
     @Autowired
     private RoleRepository roleRepository;
+    @Autowired
+    private DummyController dummyController;
 
     /**
      * 테스트용 회원가입 요청 생성
@@ -155,7 +160,7 @@ public class TestUtil {
                 .id(1L)
                 .name(RoleName.USER.name())
                 .build();
-        Member member = Member.builder()
+        return Member.builder()
                 .phoneNumber("010-1234-5678")
                 .kakaoId("kakaoId")
                 .coin(0)
@@ -164,9 +169,9 @@ public class TestUtil {
                 .profile(Profile.builder()
                         .gender(GenderType.MAN)
                         .birthDate("1999.01.01")
+                        .isProfileComplete(true)
                         .build())
                 .build();
-        return member;
     }
 
     public Image createImage() {
@@ -202,6 +207,10 @@ public class TestUtil {
                 .receiver(receiver)
                 .sendType(1)
                 .build());
+    }
+
+    public Member createTestMemberWithProfile() {
+        return dummyController.createDummyMember();
     }
 
     public String toJson(Object object) throws IOException {


### PR DESCRIPTION
## Description
@yundevingV 요청으로 Message Response에 ProfileBriefResponse 추가

## PR Checklist

- [ ] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the new behavior?
MessageSendResponse에는 receiver가 ProfileBriefRespons로 노출
MessageReceiveResponse에는 sender가 ProfileBriefRespons로 노출


## Other information
#49 