### PR TITLE
Fix: 프로필 카드 상세 조회시 memberId 추가

### DIFF
--- a/src/main/java/Dino/Duett/domain/member/repository/MemberRepository.java
+++ b/src/main/java/Dino/Duett/domain/member/repository/MemberRepository.java
@@ -11,4 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByPhoneNumber(String phoneNumber);
     boolean existsByKakaoId(String kakaoId);
     Optional<Member> findByPhoneNumber(String phoneNumber);
+    Optional<Member> findByProfileId(Long profileId);
 }

--- a/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileCardResponse.java
+++ b/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileCardResponse.java
@@ -16,6 +16,8 @@ import java.util.List;
 public class ProfileCardResponse {
     @Schema(description = "프로필 ID", example = "1")
     Long profileId;
+    @Schema(description = "멤버 ID", example = "1")
+    Long memberId;
     @Schema(description = "사용자의 이름", example = "name")
     String name;
     @Schema(description = "사용자의 생년월일", example = "2000년 01월 01일")

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileCardService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileCardService.java
@@ -52,11 +52,11 @@ public class ProfileCardService {
 
     /**
      * 잠긴 프로필 카드 목록 조회
-     * @param memberId
-     * @param page
-     * @param size
-     * @param radius
-     * @param checkProfileComplete
+     * @param memberId 사용자 id
+     * @param page 페이지
+     * @param size 사이즈
+     * @param radius 반경(km)
+     * @param checkProfileComplete 사용자 프로필 완성 여부를 확인할지 여부
      * @return ProfileLockResponse
      */
     @Transactional
@@ -277,6 +277,7 @@ public class ProfileCardService {
     private ProfileCardResponse convertToDto(Profile profile, Member member, Double distance) {
         return ProfileCardResponse.builder()
                 .profileId(profile.getId())
+                .memberId(memberRepository.findByProfileId(profile.getId()).orElseThrow(MemberException.MemberNotFoundException::new).getId())
                 .name(profile.getName())
                 .birthDate(profile.getBirthDate())
                 .mbti(profile.getMbti())


### PR DESCRIPTION
## Description
프로필 카드 상세 조회시 memberId 추가해서 쪽지 보낼 때 receiverId로 사용할 수 있도록 변경 

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
- 쪽지 수신시 profileId를 receiverId로 사용해서 메시지를 수신함.

## What is the new behavior?
- 프로필 카드 상세 조회시 memberId 추가. 쪽지 보낼 때 receiverId로 사용할 수 있도록 변경 

## Other information
#23