### PR TITLE
Feat: 마이페이지 Home API에서 자신의 프로필 완성 개수 추가

### DIFF
--- a/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileHomeResponse.java
+++ b/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileHomeResponse.java
@@ -23,6 +23,6 @@ public class ProfileHomeResponse {
     Integer introCount;
     @Schema(description = "내 음악 취향 입력 완료 개수", example = "1")
     Integer musicCount;
-    @Schema(description = "내 프로필 완성 여부", example = "true")
-    Boolean isProfileComplete;
+    @Schema(description = "완성된 프로필 정보(내 정보, 내 소개, 음악 취향) 개수", example = "true")
+    Integer unlockCount;
 }

--- a/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileHomeResponse.java
+++ b/src/main/java/Dino/Duett/domain/profile/dto/response/ProfileHomeResponse.java
@@ -23,4 +23,6 @@ public class ProfileHomeResponse {
     Integer introCount;
     @Schema(description = "내 음악 취향 입력 완료 개수", example = "1")
     Integer musicCount;
+    @Schema(description = "내 프로필 완성 여부", example = "true")
+    Boolean isProfileComplete;
 }

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
@@ -87,8 +87,22 @@ public class ProfileService {
                 .infoCount(getProfileInfoCount(profile))
                 .introCount(getProfileIntroCount(profile))
                 .musicCount(getProfileMusicCount(profile))
-                .isProfileComplete(profile.getIsProfileComplete())
+                .unlockCount(getUnlockCount(profile))
                 .build();
+    }
+
+    private int getUnlockCount(final Profile profile){
+        int count = 0;
+        if(isInfoComplete(profile)){
+            count++;
+        }
+        if(isIntroComplete(profile)){
+            count++;
+        }
+        if(isMusicTasteComplete(profile)){
+            count++;
+        }
+        return count;
     }
 
     private int getProfileInfoCount(final Profile profile){
@@ -276,11 +290,15 @@ public class ProfileService {
      * @return boolean
      */
     protected boolean isProfileComplete(final Profile profile) {
-        // 내 정보
-        boolean info = !Validator.isNullOrBlank(profile.getName()) &&
-                !Validator.isNullOrBlank(profile.getOneLineIntroduction());
+        return isInfoComplete(profile) && isIntroComplete(profile) && isMusicTasteComplete(profile);
+    }
 
-        // 내 소개
+    private boolean isInfoComplete(final Profile profile) {
+        return !Validator.isNullOrBlank(profile.getName()) &&
+                !Validator.isNullOrBlank(profile.getOneLineIntroduction());
+    }
+
+    private boolean isIntroComplete(final Profile profile) {
         int introCount = 0;
         if (profile.getMbti() != null) {
             introCount++;
@@ -294,13 +312,13 @@ public class ProfileService {
         if (!Validator.isNullOrBlank(profile.getLikeableMusicTaste())) {
             introCount++;
         }
-        boolean intro = introCount >= PROFILE_INTRO_MIN_SIZE.getLimit();
-
-        // 음악 취향
-        boolean musicTaste = profile.getMusics().size() >= MUSIC_MAX_LIMIT.getLimit();
-
-        return info && intro && musicTaste;
+        return introCount >= PROFILE_INTRO_MIN_SIZE.getLimit();
     }
+
+    private boolean isMusicTasteComplete(final Profile profile) {
+        return profile.getMusics().size() >= MUSIC_MAX_LIMIT.getLimit();
+    }
+
 
     /**
      * 프로필 정보가 처음으로 채워졌을 때 프로필 완성 여부를 업데이트

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
@@ -87,6 +87,7 @@ public class ProfileService {
                 .infoCount(getProfileInfoCount(profile))
                 .introCount(getProfileIntroCount(profile))
                 .musicCount(getProfileMusicCount(profile))
+                .isProfileComplete(profile.getIsProfileComplete())
                 .build();
     }
 


### PR DESCRIPTION
## Description
마이페이지 Home API에서 자신의 프로필 완성 개수 추가

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
마이페이지 Home API에 프로필 완성 확인 여부를 확인하는 응답을 주지 않았음.
<img width="300" alt="스크린샷 2024-07-25 오전 11 02 14" src="https://github.com/user-attachments/assets/0d968e7b-3cdf-4129-85a4-33e221ad90ca">

- 내정보, 내소개의 경우 개수를 확인해 프로필이 완성되었는지 확인할 수 있음.
- 그러나 음악취향은 무드와 상관 없이 인생곡 3개를 모두 채워야 프로필이 완성되므로, 프론트 단에서 개수를 확인해 완성되었는지 확인 불가
- 결과적으로 자신의 프로필 완성 확인을 하기 어려움


## What is the new behavior?
- 프로필 완성 개수를 응답에 포함해서 프론트에서 따로 확인을 할 필요 없도록 변경
  - unlockConut 추가
<img width="634" alt="스크린샷 2024-07-25 오전 11 00 23" src="https://github.com/user-attachments/assets/2e768cf3-1191-45d0-8895-b485951870ec">

## Other information
closed #65 