### PR TITLE
[Fix] changeMusics에 누락된 updateProfileCompleteStatusOnFirstFill 추가

### DIFF
--- a/src/main/java/Dino/Duett/domain/music/controller/MusicController.java
+++ b/src/main/java/Dino/Duett/domain/music/controller/MusicController.java
@@ -3,6 +3,8 @@ package Dino.Duett.domain.music.controller;
 import Dino.Duett.config.security.AuthMember;
 import Dino.Duett.domain.music.dto.request.MusicChangeRequest;
 import Dino.Duett.domain.music.service.MusicService;
+import Dino.Duett.domain.profile.entity.Profile;
+import Dino.Duett.domain.profile.service.ProfileService;
 import Dino.Duett.global.dto.JsonBody;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 public class MusicController {
     private final MusicService musicService;
+    private final ProfileService profileService;
 
     @Operation(summary = "자신의 인생곡 한번에 추가, 수정, 삭제하기", tags = {"마이페이지 - 음악 취향"})
     @PostMapping("/profiles/musics")
@@ -35,11 +38,12 @@ public class MusicController {
     })
     public JsonBody<Void> changeProfileMusic(@AuthenticationPrincipal final AuthMember authMember,
                                                     @RequestBody final MusicChangeRequest request){
-        musicService.changeMusics(
+        Profile profile = musicService.changeMusics(
                 authMember.getMemberId(),
                 request.getCreateLifeMusics(),
                 request.getUpdateLifeMusics(),
                 request.getDeleteLifeMusics());
+        profileService.updateProfileCompleteStatusOnFirstFill(profile);
         return JsonBody.of(HttpStatus.OK.value(), "자신의 음악 취향(인생곡과 무드) 추가, 수정, 삭제하기", null);
     }
 }

--- a/src/main/java/Dino/Duett/domain/music/service/MusicService.java
+++ b/src/main/java/Dino/Duett/domain/music/service/MusicService.java
@@ -49,7 +49,7 @@ public class MusicService {
     }
 
     @Transactional
-    public void changeMusics(final Long memberId,
+    public Profile changeMusics(final Long memberId,
                              final List<MusicCreateRequest> createMusics,
                              final List<MusicUpdateRequest> updateMusics,
                              final List<MusicDeleteRequest> deleteMusics) {
@@ -71,6 +71,7 @@ public class MusicService {
                 throw new MusicException.MusicMaxLimitException();
             }
         }
+        return profile;
     }
 
     private void createMusics(final Profile profile, final List<MusicCreateRequest> requests) {

--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
@@ -324,7 +324,7 @@ public class ProfileService {
      * 프로필 정보가 처음으로 채워졌을 때 프로필 완성 여부를 업데이트
      * @param profile 프로필
      */
-    private void updateProfileCompleteStatusOnFirstFill(Profile profile) {
+    public void updateProfileCompleteStatusOnFirstFill(Profile profile) {
         if(isProfileComplete(profile) && !profile.getIsProfileComplete()){
             profile.updateIsProfileComplete(true);
         }


### PR DESCRIPTION
## Description
fix: changeMusics에 누락된 updateProfileCompleteStatusOnFirstFill 추가

## PR Checklist

- [ ] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the new behavior?
프로필의 모든 필드를 채워야 합니다 에러 수정

## Other information