### PR TITLE
Fix: 음악 취향 변경시 프로필 완성 여부를 업데이트 안되는 문제 해결

### DIFF
--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileService.java
@@ -291,6 +291,7 @@ public class ProfileService {
      * 프로필 정보가 처음으로 채워졌을 때 프로필 완성 여부를 업데이트
      * @param profile 프로필
      */
+    @Transactional
     public void updateProfileCompleteStatusOnFirstFill(Profile profile) {
         if(isProfileComplete(profile) && !profile.getIsProfileComplete()){
             profile.updateIsProfileComplete(true);


### PR DESCRIPTION
## Description
음악 취향 변경시 프로필 완성 여부를 업데이트 안되는 문제 해결

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
음악취향의 음악 3곡을 채우게되면 프로필 완성 여부가 true가 되어야 하는데 안됨.

## What is the new behavior?
<img width="611" alt="스크린샷 2024-07-30 오후 1 59 17" src="https://github.com/user-attachments/assets/31aa813b-4db8-4a53-b660-c61352033fcd">

private 메서드를 public으로 바꾸면서 클래스 외부에서 접근하도록 변경하면서, updateProfileCompleteStatusOnFirstFill 메서드에 @Transactional이 누락됨.
따라서 @Transactional를 추가함으로써 해결
## Other information
closed #73 