### PR TITLE
[fix] profile_lock 테이블에 viewer_profile_id, viewed_profile_id 후보키 설정

### DIFF
--- a/src/main/java/Dino/Duett/domain/profile/entity/ProfileUnlock.java
+++ b/src/main/java/Dino/Duett/domain/profile/entity/ProfileUnlock.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "profile_unlock")
+@Table(name = "profile_unlock", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"viewer_profile_id", "viewed_profile_id"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ProfileUnlock extends BaseEntity {


### PR DESCRIPTION
## Description
profile_lock 테이블에 viewer_profile_id, viewed_profile_id 후보키 설정

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes

## What is the new behavior?
profile_lock 테이블에 viewer_profile_id, viewed_profile_id 후보키 설정

## Other information
#81 