### PR TITLE
[feat] TimeZone Aisa/Seoul 적용

### DIFF
--- a/src/main/java/Dino/Duett/DuettApplication.java
+++ b/src/main/java/Dino/Duett/DuettApplication.java
@@ -4,9 +4,17 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableJpaAuditing
 public class DuettApplication {
+
+	@PostConstruct
+	void setTImeZone() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(DuettApplication.class, args);


### PR DESCRIPTION
## Description
TimeZone Aisa/Seoul을 적용하여 한국 시간에 맞게 DB에 date 정보가 저장되게 합니다.

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
DB에 date 정보가 표준 시간(9시간 전)으로 저장됨

## What is the new behavior?
이제 DB date 정보가 한국 시간에 맞게 저장됩니다.
