### PR TITLE
Fix: 열어본 프로필 목록에서 다른 Tag를 가져오는 문제 해결

### DIFF
--- a/src/main/java/Dino/Duett/domain/profile/service/ProfileUnlockService.java
+++ b/src/main/java/Dino/Duett/domain/profile/service/ProfileUnlockService.java
@@ -61,7 +61,7 @@ public class ProfileUnlockService {
                                         profileUnlock.getViewedProfile().getMusics().get(0).getTitle(),
                                         profileUnlock.getViewedProfile().getMusics().get(0).getArtist()
                                 ) : null)
-                .tags(profileTagService.getProfileTagsOnlyFeatured(profileUnlock.getId()))
+                .tags(profileTagService.getProfileTagsOnlyFeatured(profileUnlock.getViewedProfile().getId()))
                 .build()).stream()
                 .toList();
     }


### PR DESCRIPTION
## Description
열어본 프로필 목록에서 다른 Tag를 가져오는 문제 해결

## PR Checklist

- [x] 커밋 컨벤션을 지켜서 작성했는가?
- [ ] 기능 추가의 경우 테스트 코드를 작성했는가?
- [ ] 기능 변경의 경우 문서를 업데이트했는가?
- [ ] 코드 리뷰를 진행했는가?


## PR Type
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes


## What is the current behavior?
열어본 프로필 목록에서 다른 Tag를 가져옴

## What is the new behavior?
열어본 프로필 목록에서 다른 Tag를 가져오는 문제 해결

## Other information
closed #87 